### PR TITLE
Nuetral delims support + options to ignore strings/comments.

### DIFF
--- a/paren-completer.el
+++ b/paren-completer.el
@@ -25,8 +25,7 @@
 ;;; Commentary:
 
 ;; Provides 4 functions to generically auto-complete delimiters.
-;; Avoids use of syntax table, instead relies on user defined lists.
-;; (The syntax table didn't seem to have everything I wanted, like <> brackets in c++.)
+;; Avoids use of syntax table, instead relies on user defined lists.(except for strings and comments)
 ;; See readme.org
 
 ;;; Code:

--- a/paren-completer.el
+++ b/paren-completer.el
@@ -6,7 +6,7 @@
 ;; Mantainer: Matthew Bregg
 ;; Keywords: convenience
 ;; URL: https://github.com/MatthewBregg/paren-completer
-;; Version: 1.3.1
+;; Version: 1.3.2
 ;; Package-Requires: ((emacs "24.3"))
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -40,9 +40,9 @@
 
 
 
-(defcustom paren-completer--open-delimiter-list (list ?\( ?\[ ?\< ?\{ )
+(defcustom paren-completer--open-delimiter-list (list ?\( ?\[ ?\{ )
   "List of opening delimiters to look for.  Must be in same order as close-delimiter-list.")
-(defcustom paren-completer--close-delimiter-list (list ?\) ?\] ?\> ?\} )
+(defcustom paren-completer--close-delimiter-list (list ?\) ?\] ?\} )
   "List of closing delimiters to look for.  Must be in same order as open-delimiter-list.")
 ;(defvar paren-completer--neutral-delimiter-list (list ?\' ?\") "List of nuetral delimiters.  Not used atm.")
 (defcustom paren-completer--complete-stringsp? t "If true, will attempt to close strings as well.")

--- a/readme.org
+++ b/readme.org
@@ -49,5 +49,13 @@ Is quite problematic.
 Caching the point won't work, because it's too easy to be at the same point, despite having made changes.
 Could make a hook to hook into on buffer change, but that would likely cancel any performance gains, might as well just run it multiple times.... ( Plus that's a bit uglier.)
 
+* Customizations
+- paren-completer--complete-stringsp? : If true, use the syntax table to auto-close strings also.
+- paren-completer--ignore-commentsp? : If true, ignore delimiters in comments
+- paren-completer--ignore-stringsp? : If true, ignore delimiters within strings
+  
+* TODO
+- Possibly use http://www.gnu.org/software/emacs/manual/html_node/elisp/Parser-State.html#Parser-State to avoid scanning everything? Future thing to do...
+- Switch to the syntax table for checking delimiters, original reason not to is gone....
 
 


### PR DESCRIPTION
Also removed < from default list, as I can't really tell when it's used as a delimiter, vs less than/greater than.....
